### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Gtranslator.yml
+++ b/org.gnome.Gtranslator.yml
@@ -5,7 +5,6 @@ runtime-version: 3.30
 sdk: org.gnome.Sdk
 command: gtranslator
 build-options:
-  cflags: '-O2 -g'
   env:
     PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR: /app/share/gir-1.0
     PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR: /app/lib/girepository-1.0


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.