### PR TITLE
Mark modules as normal

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "require-important-update": true
-}

--- a/org.gnome.Gtranslator.yml
+++ b/org.gnome.Gtranslator.yml
@@ -36,7 +36,6 @@ modules:
         x-checker-data:
           type: gnome
           name: libspelling
-          is-important: true
 
   - name: gtranslator
     buildsystem: meson
@@ -47,4 +46,3 @@ modules:
         x-checker-data:
           type: gnome
           name: gtranslator
-          is-important: true


### PR DESCRIPTION
This project has two modules, and both of them appear to be marked as important. This usage makes the "require-important-update": true setting redundant.

Fixes: https://github.com/flathub/org.gnome.Gtranslator/issues/39